### PR TITLE
Tokens de nova linha

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 # ----------------------- || -------------
 
 set(CMAKE_C_FLAGS_DEBUG "-g")
+set(CMAKE_BUILD_TYPE Debug)
 
 include_directories(${GTK3_INCLUDE_DIRS}) 
 include_directories(${CMAKE_SOURCE_DIR}/include)

--- a/include/montador_types.h
+++ b/include/montador_types.h
@@ -46,6 +46,7 @@ enum t_types {
     TOK_WRITE        = 1013,
     TOK_PUT          = 1014,
     TOK_SPACE        = 1015,
+    TOK_NEWLINE      = 1016,
     TOK_EOF          = 1020,
     T_TYPES_SIZE
 };

--- a/src/maquina.c
+++ b/src/maquina.c
@@ -46,6 +46,7 @@ const char * const tok_colors[] = {
     [TOK_ADDRESSING]      = "orange",
     [TOK_SECTION]         = "red",
     [TOK_IDENTIFIER]      = "blue",
+    [TOK_NEWLINE]         = NULL,
 
 };
 

--- a/src/montador.c
+++ b/src/montador.c
@@ -304,17 +304,26 @@ token_t nextToken( program_t *program ) {
         switch (program->source[program->HEAD])
         {
             case '\r':
+                token_n->token   = "\\n";
+                token_n->defined = true;
+                token_n->value   = -1;
+                token_n->type    = TOK_NEWLINE;
+                
                 // CRLF
                 if ( peek(program->source, program->HEAD) == '\n' )
                 {
                     program->HEAD += 2;
                     program->c_row++;
                     program->c_col = 1;
+
+                    return *token_n;
                 // CR
                 } else
                 {
                     program->HEAD++;
                     program->c_col = 1;
+
+                    return *token_n;
                 }
                 break;
             // LF
@@ -322,6 +331,14 @@ token_t nextToken( program_t *program ) {
                 program->HEAD++;
                 program->c_row++;
                 program->c_col = 1;
+
+                token_n->token   = "\\n";
+                token_n->defined = true;
+                token_n->value   = -1;
+                token_n->type    = TOK_NEWLINE;
+
+                return *token_n;
+
                 break;
             case '\t':
             case ' ':


### PR DESCRIPTION
Terminadores de linha serão tokenizados na etapa de tokenização. No futuro estes tokens serão necessários no processamento de macros pois linhas têm significado semântico em macros.

Por exemplo,
```
%macro MAC PARAM1 PARAM2 PARAM3
    LOAD PARAM1
    ADD  PARAM2
    STORE PARAM3
%endmacro
```
nesse caso, os parâmetros são delimitados pelo fim da linha %macro e o valor do macro começa na próxima linha.

Até onde foi possível verificar, a adição destes tokens não afeta a montagem pois tokens desconhecidos são ignorados. De fato, havia um bug, que foi corrigido inadvertidamente com a contagem de linhas e colunas, que fazia com que sempre houvesse um token não inicializado antes do token EOF, e isso não causava problemas se o tipo não fosse aleatoriamente um valor válido.

Por enquanto estes tokens não têm nenhuma utilidade, mas como dito anteriormente, terão uso no processamento de macros.