### PR TITLE
Melhorada instrução COPY no montador e no parser.

### DIFF
--- a/src/montador.c
+++ b/src/montador.c
@@ -1588,6 +1588,10 @@ void parse( program_t *program )
                 rv = parseEXTERN(program, tok);
             break;
 
+            case TOK_COPY:
+                rv = parseCopy(program, tok);
+            break;
+
             default:
             break;
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -1101,3 +1101,178 @@ int parseStore( program_t *program, token_t *c_tok )
     return EXIT_SUCCESS;
 }
 
+enum copy_address{
+    UNDEFINED,
+    DIRECT,
+    INDIRECT,
+    IMMEDIATE
+};
+
+int parseCopy(program_t *program, token_t *c_tok){
+    // apos deteccao do token copy, obtem proximo token
+    token_t *peeked_1, *peeked_2; //para percorrer os tokens
+    bool defined;
+    token_t *t; //para procurar na tabela de simbolos
+
+    enum copy_address op1_type = UNDEFINED, op2_type = UNDEFINED;
+    word_t op1_value, op2_value;
+    bool op2_defined = false; //ate resolver o operando 2
+
+    do{
+
+        peeked_1 = getNextToken(program);
+
+        switch (peeked_1->type){
+
+            case TOK_ADDRESSING: //caso tenha token definindo enderecamento
+                peeked_2 = getNextToken( program );
+                if ( strncmp( peeked_1->token, "&", 2 ) == 0 ){ //direto: simbolo &
+                    //insert( program->sections->dot_text, LOAD_DIRECT  );
+                    if(op1_type == UNDEFINED){
+                        op1_type = DIRECT;
+                    } else {
+                        op2_type = DIRECT;
+                    }
+                }else // indireto: simbolo #
+                {
+                    //insert( program->sections->dot_text, LOAD_INDIRECT );
+                    if(op1_type == UNDEFINED){
+                        op1_type = INDIRECT;
+                    } else {
+                        op2_type = INDIRECT;
+                    }
+                }
+
+                // proximo token: identificador ou literal
+                if (peeked_2->type == TOK_IDENTIFIER){ //identificador
+
+                    HASH_FIND_STR(program->table->tokens, peeked_2->token, t);
+                    
+                    if ( t == NULL ){ //se nao encontrado, aponta erro
+                        goto not_defined;
+                    } else {
+                        //insert( program->sections->dot_text, t->value );
+                        if(op2_type == UNDEFINED){
+                            op1_value = t->value;
+                        } else {
+                            op2_value = t->value;
+                            op2_defined = true;
+                        }
+                    }
+                } else if ( peeked_2->type == TOK_LITERAL ||
+                    peeked_2->type == TOK_LITERAL_HEX ){ //literal
+                    //insert( program->sections->dot_text, peeked_2->value );
+                    if(op2_type == UNDEFINED){
+                            op1_value = peeked_2->value;
+                        } else {
+                            op2_value = peeked_2->value;
+                            op2_defined = true;
+                        }
+                } else { //caso token inesperado, aponta erro
+                
+                    current_parser_error = 
+                        realloc ( current_parser_error, 100 + strlen(peeked_1->token) );
+                    sprintf( current_parser_error, 
+                        "Expected token ( TOK_LITERAL ||"
+                        " TOK_IDENTIFIER || TOK_LITERAL_HEX )"
+                        " found : %s", peeked_1->token );
+                    return -1;
+                }
+                break;
+            
+            case TOK_LITERAL: //imediato
+            case TOK_LITERAL_HEX:
+                //insert( program->sections->dot_text, LOAD_IMMEDIATE  );
+                //insert( program->sections->dot_text, peeked_1->value );
+                if(op1_type == UNDEFINED){
+                    //op1_type = IMMEDIATE;
+                    //op1_value = peeked_1->value;
+                    // operando 1 nao pode ser imediato, entao aponta erro
+                    current_parser_error = realloc (current_parser_error, 100 + strlen(peeked_1->token));
+                    snprintf( current_parser_error, 100,
+                        "Expected token (TOK_ADDRESSING ||"
+                        " TOK_IDENTIFIER) for first operand"
+                        " in COPY instruction. Found : %s", peeked_1->token );
+                    return -1;
+                } else {
+                    op2_type = IMMEDIATE;
+                    op2_value = peeked_1->value;
+                    op2_defined = true;
+                }
+                break;
+            
+            case TOK_IDENTIFIER: //identificador
+                HASH_FIND_STR( program->table->tokens, peeked_1->token, t );
+                if ( t == NULL )
+                {
+            not_defined:
+                    current_parser_error = 
+                        realloc ( current_parser_error, 25 + strlen(peeked_1->token) );
+                    sprintf( current_parser_error, 
+                            "Undefined identifier : %s", peeked_1->token );
+                    return -1;
+                } else {
+                    //insert( program->sections->dot_text, LOAD_DIRECT );
+                    //insert( program->sections->dot_text, t->value    );
+                    if(op1_type == UNDEFINED){
+                        op1_type = DIRECT;
+                        op1_value = t->value;
+                    } else {
+                        op2_type = DIRECT;
+                        op2_value = t->value;
+                        op2_defined = true;
+                    }
+                }
+                break;
+
+            default:
+                current_parser_error = 
+                    realloc ( current_parser_error, 100 + strlen(peeked_1->token) );
+                snprintf( current_parser_error, 100,
+                        "Expected token ( TOK_ADDRESSING ||"
+                        " TOK_IDENTIFIER || TOK_LITERAL"
+                        " || TOK_LITERAL_HEX ) found : %s", peeked_1->token );
+                return -1;
+        }
+    }while(op2_defined == false);
+
+    //temporario
+    if(op1_type == IMMEDIATE){ return -1; }
+
+    // depois de analisado, insere a instrucao
+    switch (op1_type){
+        case DIRECT:
+            switch (op2_type) {
+                case DIRECT:        // DIRECT vs DIRECT
+                    insert( program->sections->dot_text, COPY_DD );
+                    break;
+                case INDIRECT:      // DIRECT vs INDIRECT
+                    insert( program->sections->dot_text, COPY_DI );
+                    break;
+                case IMMEDIATE:     // DIRECT vs IMMEDIATE
+                    insert( program->sections->dot_text, COPY_DIm );
+                    break;
+            }
+            break;
+
+        case INDIRECT:
+            switch (op2_type) {
+                case DIRECT:        // INDIRECT vs DIRECT
+                    insert( program->sections->dot_text, COPY_ID );
+                    break;
+                case INDIRECT:      // INDIRECT vs INDIRECT
+                    insert( program->sections->dot_text, COPY_II );
+                    break;
+                case IMMEDIATE:     // INDIRECT vs IMMEDIATE
+                    insert( program->sections->dot_text, COPY_IIm );
+                    break;
+            }
+            break;
+    }
+    
+    //apos resolver a instrucao, insere os 2 operandos
+    insert(program->sections->dot_text, op1_value);
+    insert(program->sections->dot_text, op2_value);
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Instrução COPY foi melhorada nos arquivos src/montador.c e src/parser.c. Foram feitos alguns testes aplicando a instrução COPY num arquivo .asm individual, dentro de uma macro e em um módulo que não o principal. Sujeito a revisão.